### PR TITLE
Fix TX-search (status of last restake time on validators modal)

### DIFF
--- a/src/utils/QueryClient.mjs
+++ b/src/utils/QueryClient.mjs
@@ -204,8 +204,10 @@ const QueryClient = async (chainId, restUrls, opts) => {
     params.forEach(({ key, value }) => {
       searchParams.append(key, value);
     });
-    if (pageSize)
+    if (pageSize) {
       searchParams.append('pagination.limit', pageSize);
+      searchParams.append('limit', pageSize);
+    }
     if (order)
       searchParams.append('order_by', order);
     const client = axios.create({ baseURL: restUrl });


### PR DESCRIPTION
![restake_txs_problem](https://github.com/staking-explorer/restake-ui/assets/128298682/8fed9f30-68cf-4875-9513-e6c7de45d9a6)

QueryClient.mjs changed to fix the issue on screenshot above. 

Description.
In newer versions of SDK parameter "pagination.limit" replaced by "limit". Also parameter "pagination.offset" replaced by "page". The simplest way to fix the issue on screenshot above is just adding additional parameter to query (this will work for chains with old SDK and for chains with newer versions of SDK).

Issue reproduction.
We need to choose a validator with a large number of delegators. Since the parameter limiting the number of transactions per page to one will not work, the REST API node will try to send one hundred transactions per page. However, due to the fact that there is a whole bunch of MsgDelegate in one transaction, the size of such a page will be too large. The output will be 500, 429 error. And the status circle will rotate endlessly.